### PR TITLE
fixes chap2 docker-compose.yml comments

### DIFF
--- a/Chapter 2/02 - Setting up complex environments/docker-compose.yml
+++ b/Chapter 2/02 - Setting up complex environments/docker-compose.yml
@@ -7,12 +7,12 @@ services:
     build: .
 
     # this is equivalent to "-p" option of
-    # the "docker build" command
+    # the "docker run" command
     ports:
     - "5000:5000"
 
     # this is equivalent to "-t" option of
-    # the "docker build" command
+    # the "docker run" command
     tty: true
 
   database:


### PR DESCRIPTION
-p and -t are "docker run" options insted of "docker build"