### PR TITLE
fixes chap10. Delete setup.cfg for mutmut in pytest samples.

### DIFF
--- a/Chapter 10/02 - Test parametrization/setup.cfg
+++ b/Chapter 10/02 - Test parametrization/setup.cfg
@@ -1,6 +1,0 @@
-[mutmut]
-paths_to_mutate=batch.py
-backup=False
-runner=python -m pytest -x
-tests_dir=.
-dict_synonyms=Struct, NamedStruct


### PR DESCRIPTION
mutmut settings is not for this directory.