### PR TITLE
Fix Chap6 docstring mistakes

### DIFF
--- a/Chapter 6/06 - Dealing with errors in threads/error_handling.py
+++ b/Chapter 6/06 - Dealing with errors in threads/error_handling.py
@@ -1,7 +1,6 @@
 """
 "An example of a threaded application" section example
-showing how throttling / rate limiting can be implemented
-in multithreaded application
+Dealing with errors in threads
 
 """
 import random


### PR DESCRIPTION
The docstring was identical for the two files mentioned below.
I have made modifications to the error_handling.py.

* Chapter 6/06 - Dealing with errors in threads/error_handling.py
* Chapter 6/07 - Throttling/throttling.py